### PR TITLE
Fix for CMP0048 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION  2.8)
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif(POLICY CMP0048)
 project(coredumper C CXX)
-
 # We do not wish to work without threading support
 # TODO: remove related ifdefs
 set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
Adjusted CMake VERSION variables to fix CMP0048 policy warning.