### PR TITLE
Changed cmake_minimum_required VERSION to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION  2.8)
+cmake_minimum_required(VERSION  2.8.12)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif(POLICY CMP0048)


### PR DESCRIPTION
Newer CMake binaries started to generate a warning if 'cmake_minimum_required' 'VERSION' is less than '2.8.12'. Increased this 'VERSION' to suppress the warning.